### PR TITLE
Correction du lien de l'archive

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
             FHap by FHaP			
         </div>
         <div style="font-size:80%; text-align:center; padding: 1em;">
-		<a href="2015/index.html">Archive</a> 2015 du FHaP aussi disponible <a href="http://fhap.leloop.org">ici</a>
+		Archive 2015 du FHaP aussi disponible <a href="2015/index.html">ici</a>
         </div>
         </footer>
 </body>


### PR DESCRIPTION
Le lien sur « ici » menait à l'accueil en raison d'une redirection depuis l'ancienne adresse. J'ai corrigé le bon lien et du coup retiré celui sous « Archive ».
